### PR TITLE
The macs executable is called macs.so not macs

### DIFF
--- a/macs/macs.so.cpp
+++ b/macs/macs.so.cpp
@@ -130,7 +130,7 @@ void user_t::simulate() {
 //  It is assumed that MaCS is in the search path
 //  ./macs <parameters> | allele_spectrum | cut -f3- | sed 1d
 
-	cmd<<"macs/macs 718 100000 -s "<<seed<<" -t .001 -I 3 176 170 372 0 -m 2 1 "<<param->MigrationRate_AfrToEur<<" -m 3 1 "<<param->MigrationRate_AfrToAsn<<" -m 3 2 "<<param->MigrationRate_EurToAsn<<" -n 1 "<<param->EffectivePopulationSize_Afr<<" -g 2 "<<param->GrowthRate_Eur<<" -g 3 "<<param->GrowthRate_Asn<<" -eg .0230000 2 0 -eg .0230001 3 0 -ej .0230002 3 2 -em .0230003 2 1 "<<param->PastEvent_AfrToEurProportion<<" -en .0230004 2 0.1861 -ej .051 2 1 -en .148 1 0.731 -r 0.0006  2>/dev/null |   macs/allele_spectrum | cut -f3- | sed 1d";
+	cmd<<"macs/macs.so 718 100000 -s "<<seed<<" -t .001 -I 3 176 170 372 0 -m 2 1 "<<param->MigrationRate_AfrToEur<<" -m 3 1 "<<param->MigrationRate_AfrToAsn<<" -m 3 2 "<<param->MigrationRate_EurToAsn<<" -n 1 "<<param->EffectivePopulationSize_Afr<<" -g 2 "<<param->GrowthRate_Eur<<" -g 3 "<<param->GrowthRate_Asn<<" -eg .0230000 2 0 -eg .0230001 3 0 -ej .0230002 3 2 -em .0230003 2 1 "<<param->PastEvent_AfrToEurProportion<<" -en .0230004 2 0.1861 -ej .051 2 1 -en .148 1 0.731 -r 0.0006  2>/dev/null |   macs/allele_spectrum | cut -f3- | sed 1d";
 
 	exec_cmd(cmd.str().c_str());
 


### PR DESCRIPTION
The example executable created by the Makefile is called macs.so, not macs.